### PR TITLE
chore: remove close Run

### DIFF
--- a/src/client/api/runs.ts
+++ b/src/client/api/runs.ts
@@ -8,7 +8,6 @@ import {
 	GetRunsInputType,
 	AddRunInputType,
 	UpdateRunInputType,
-	CloseRunInputType,
 } from "../../shared/schemas/runs.js";
 
 export class RunsClient extends BaseTestRailClient {
@@ -94,23 +93,6 @@ export class RunsClient extends BaseTestRailClient {
 			return response.data;
 		} catch (error) {
 			throw handleApiError(error, `Failed to update test run ${runId}`);
-		}
-	}
-
-	/**
-	 * Closes a test run
-	 * @param runId The ID of the test run
-	 * @returns Promise with closed test run
-	 */
-	async closeRun(runId: CloseRunInputType["runId"]): Promise<TestRailRun> {
-		try {
-			const response: AxiosResponse<TestRailRun> = await this.client.post(
-				`/api/v2/close_run/${runId}`,
-				{},
-			);
-			return response.data;
-		} catch (error) {
-			throw handleApiError(error, `Failed to close test run ${runId}`);
 		}
 	}
 

--- a/src/server/api/runs.ts
+++ b/src/server/api/runs.ts
@@ -6,7 +6,6 @@ import {
 	getRunSchema,
 	addRunSchema,
 	updateRunSchema,
-	closeRunSchema,
 } from "../../shared/schemas/runs.js";
 
 /**
@@ -182,36 +181,6 @@ export function registerRunTools(
 			} catch (error) {
 				const errorResponse = createErrorResponse(
 					`Error updating test run ${runId}`,
-					error,
-				);
-				return {
-					content: [{ type: "text", text: JSON.stringify(errorResponse) }],
-					isError: true,
-				};
-			}
-		},
-	);
-
-	// Close a test run
-	server.tool(
-		"closeRun",
-		"Closes a test run / テスト実行を終了します",
-		closeRunSchema,
-		async ({ runId }) => {
-			try {
-				const run = await testRailClient.runs.closeRun(runId);
-				const successResponse = createSuccessResponse(
-					"Test run closed successfully",
-					{
-						run,
-					},
-				);
-				return {
-					content: [{ type: "text", text: JSON.stringify(successResponse) }],
-				};
-			} catch (error) {
-				const errorResponse = createErrorResponse(
-					`Error closing test run ${runId}`,
 					error,
 				);
 				return {

--- a/src/shared/schemas/runs.ts
+++ b/src/shared/schemas/runs.ts
@@ -79,24 +79,18 @@ export const updateRunSchema = {
 	refs: z.string().optional().describe("Reference/requirement IDs"),
 };
 
-// Schema for closing a test run
-export const closeRunSchema = {
-	runId: z.number().describe("TestRail Run ID"),
-};
 
 // Create Zod objects from each schema
 export const GetRunsInput = z.object(getRunsSchema);
 export const GetRunInput = z.object(getRunSchema);
 export const AddRunInput = z.object(addRunSchema);
 export const UpdateRunInput = z.object(updateRunSchema);
-export const CloseRunInput = z.object(closeRunSchema);
 
 // Extract input types
 export type GetRunsInputType = z.infer<typeof GetRunsInput>;
 export type GetRunInputType = z.infer<typeof GetRunInput>;
 export type AddRunInputType = z.infer<typeof AddRunInput>;
 export type UpdateRunInputType = z.infer<typeof UpdateRunInput>;
-export type CloseRunInputType = z.infer<typeof CloseRunInput>;
 
 // -----------------------------------------------
 // Response schema definitions - migrated from types.ts

--- a/test/client/api/runs.spec.ts
+++ b/test/client/api/runs.spec.ts
@@ -173,24 +173,4 @@ describe('Runs API', () => {
     expect(result).toEqual(mockRun);
   });
   
-  it('closes a run', async () => {
-    // Mock response
-    const mockRun = {
-      id: 1,
-      name: 'Test Run 1',
-      is_completed: true,
-      completed_on: 1619827200,
-      url: 'http://example.com/run/1'
-    };
-    mockAxiosInstance.post.mockResolvedValue({ data: mockRun });
-    
-    // Test method
-    const result = await client.runs.closeRun(1);
-    
-    // Verify axios post was called correctly
-    expect(mockAxiosInstance.post).toHaveBeenCalledWith('/api/v2/close_run/1', {});
-    
-    // Verify result
-    expect(result).toEqual(mockRun);
-  });
 }); 


### PR DESCRIPTION
## What

- Remove `closeRun`

## Why

- Cursor, one of the most powerful MCP clients, has a limitation on the number of tools
- So, I'd like to remove unnecessary tools