### PR TITLE
docs(readme): expand Troubleshooting with `spawn npx ENOENT` guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,43 @@ You can connect this MCP server by setting like the below. This method uses `npx
 
 ## Troubleshooting
 
-- **`spawn node ENOENT` errors**: Ensure that Node.js is properly installed and in your PATH.
+- **`spawn npx ENOENT` / `spawn node ENOENT` (commonly on macOS)**: your MCP host (Cursor, Claude Code, Claude Desktop, …) cannot find `npx` or `node` at process-spawn time. The chat UI usually surfaces this as a generic "MCP server doesn't work" with no useful detail; the per-server log is the diagnostic source of truth.
+
+  **Why it happens on macOS:** GUI apps launched from the Dock, Spotlight, or Finder inherit launchd's minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`). If you installed Node via a version manager (`nvm`, `asdf`, `mise`, `fnm`, `Volta`) or Apple Silicon Homebrew (`/opt/homebrew/bin/`), `npx` lives outside that PATH — only your shell startup file (`~/.zshrc` / `~/.bashrc`) adds it. Your terminal works because the shell ran the startup file; the GUI-app process never did.
+
+  **Diagnose** by checking the per-server log for `spawn npx ENOENT`:
+
+  - **Cursor:** `~/Library/Application Support/Cursor/logs/<session>/window<N>/exthost/anysphere.cursor-mcp/MCP <server>.log`
+  - **Claude Code / Claude Desktop:** `~/Library/Logs/Claude/`
+
+  **Fix** by replacing `"npx"` in your MCP config with its absolute path. Run `which npx` in your normal terminal:
+
+  ```text
+  /Users/you/.nvm/versions/node/v24.15.0/bin/npx   # nvm
+  /opt/homebrew/bin/npx                            # Apple Silicon Homebrew
+  /usr/local/bin/npx                               # Intel Homebrew / system Node
+  ```
+
+  Then update your MCP config:
+
+  ```json
+  {
+    "mcpServers": {
+      "testrail": {
+        "command": "/Users/you/.nvm/versions/node/v24.15.0/bin/npx",
+        "args": ["@bun913/mcp-testrail@latest"],
+        "env": {
+          "TESTRAIL_URL": "https://your-instance.testrail.io",
+          "TESTRAIL_USERNAME": "your-email@example.com",
+          "TESTRAIL_API_KEY": "YOUR_API_KEY"
+        }
+      }
+    }
+  }
+  ```
+
+  Restart your MCP client after the change. The same fix applies to every `npx`-launched MCP server — if `mcp-testrail` is failing for this reason, your other `npx`-launched servers are likely failing too.
+
 - **Authentication issues**: Check your TestRail API credentials.
 - **Your conversation is too long**: Use `limit` and `offset` parameters for test cases and sections to paginate results.
 - **HTTP 400 errors when creating/updating test cases**: TestRail projects have different templates, custom fields, and required fields. This MCP server passes your parameters directly to the TestRail API — it does not validate or transform them. If you encounter 400 errors, define your project's rules in `CLAUDE.md` or `AGENTS.md` so the LLM sends the correct parameters. For example:


### PR DESCRIPTION
## Related Issue

Closes #136

## Summary

Companion to #137 (issue template). The README's Troubleshooting section had a one-line `spawn node ENOENT` bullet that didn't explain the most common failure mode reporters were hitting on macOS: GUI apps (Cursor, Claude Code, Claude Desktop, …) inherit launchd's minimal PATH and cannot find `npx` when Node is installed via nvm / asdf / mise / fnm / Volta / Apple Silicon Homebrew. The chat UI surfaces this as a generic "MCP server doesn't work" with no useful detail, so reporters land on issue #136 without the per-server log line that identifies it.

This rewrites the bullet to:

- Cover both `spawn npx ENOENT` and `spawn node ENOENT`.
- Explain the launchd vs shell PATH gap and which installers leak outside launchd's default PATH.
- Point at the per-server log path on Cursor + Claude Code / Desktop so reporters can self-diagnose.
- Show the absolute-path fix (replace `"npx"` with `which npx` output) with a JSON example mirroring the README's Usage block.
- Note that the fix applies to every `npx`-launched MCP server, not just `mcp-testrail`.

Background: this is the README counterpart to the diagnosis posted in https://github.com/bun913/mcp-testrail/issues/136#issuecomment-4636596356. PR #137 already added the issue-template "Before reporting" guidance; this completes the loop on the README so users find the fix before they file an issue.

## Test Plan

- [x] No code changes — `biome format` (src/) and `vitest` (test/) are unaffected by README edits.
- [x] Markdown rendered locally; code fences and nested list indentation verified.
- [x] N/A `npm test` / `npm run build` / MCP Inspector — README-only.